### PR TITLE
.jinja2 recognised as a html/jinja template.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 					"Jinja",
 					"HTML"
 				],
-                "extensions": [".j2", ".html", ".htm"],
+                "extensions": [".j2", ".jinja2", ".html", ".htm"],
 				"configuration": "./jinja-html.configuration.json"
 			},
 			{


### PR DESCRIPTION
Only a small change so that files with the .jinja2 extension are recognised as jinja html templates.
