### PR TITLE
Add .tera support

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 				"aliases": [
 					"Jinja"
 				],
-                "extensions": [".j2"],
+                "extensions": [".j2", ".tera"],
 				"configuration": "./jinja.configuration.json"
 			},
 			{
@@ -40,7 +40,7 @@
 					"Jinja",
 					"HTML"
 				],
-                "extensions": [".j2", ".jinja2", ".html", ".htm"],
+                "extensions": [".j2", ".jinja2", ".tera", ".html", ".htm"],
 				"configuration": "./jinja-html.configuration.json"
 			},
 			{

--- a/syntaxes/jinja-html.json
+++ b/syntaxes/jinja-html.json
@@ -4,6 +4,7 @@
     "comment": "Jinja Template Engine in HTML",
     "fileTypes": [
         "j2",
+        "tera",
         "html"
     ],
     "firstLineMatch": "^{% extends [\"'][^\"']+[\"'] %}",

--- a/syntaxes/jinja.json
+++ b/syntaxes/jinja.json
@@ -2,7 +2,7 @@
 	"name": "jinja",
 	"scopeName": "source.jinja",
 	"comment": "Jinja Template Engine",
-	"fileTypes": ["j2"],
+	"fileTypes": ["j2", "tera"],
 	"foldingStartMarker": "({%\\s*(block|filter|for|if|macro|raw))",
 	"foldingStopMarker": "({%\\s*(endblock|endfilter|endfor|endif|endmacro|endraw)\\s*%})",
 	"patterns": [


### PR DESCRIPTION
[Tera](https://github.com/Keats/tera) is a Jinja2-compatible template engine for Rust.

It would be great to be able to use VS Code's syntax highlighting with `.tera` files, so I added support for those to the extension.